### PR TITLE
In iOS 13 present the hppViewController in full screen mode to avoid problems when the user dismisses with a gesture

### DIFF
--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -222,6 +222,7 @@ open class HPPManager: NSObject, UIWebViewDelegate, HPPViewControllerDelegate {
         if  self.HPPRequestProducerURL.absoluteString != "" {
             self.getHPPRequest()
             let navigationController = UINavigationController(rootViewController: self.hppViewController)
+            navigationController.modalPresentationStyle = .fullScreen
             viewController.present(navigationController, animated: true, completion: nil)
         } else {
             // error


### PR DESCRIPTION
To get the same behaviour as previous versions of iOS when presenting the HPP