### PR TITLE
HPPManager now completes with result dictionary of <String, Any>

### DIFF
--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -9,7 +9,7 @@ import UIKit
  */
 @objc public protocol HPPManagerDelegate {
 
-    @objc optional func HPPManagerCompletedWithResult(_ result: Dictionary <String, String>);
+    @objc optional func HPPManagerCompletedWithResult(_ result: Dictionary <String, Any>);
     @objc optional func HPPManagerFailedWithError(_ error: NSError?);
     @objc optional func HPPManagerCancelled();
 
@@ -447,7 +447,7 @@ open class HPPManager: NSObject, UIWebViewDelegate, HPPViewControllerDelegate {
 
                 if let receivedData = data {
                     // success
-                    let decodedResponse = try JSONSerialization.jsonObject(with: receivedData, options: [JSONSerialization.ReadingOptions.allowFragments]) as! Dictionary <String, String>
+                    let decodedResponse = try JSONSerialization.jsonObject(with: receivedData, options: [JSONSerialization.ReadingOptions.allowFragments]) as! Dictionary <String, Any>
                     self.delegate?.HPPManagerCompletedWithResult!(decodedResponse)
                 }
                 else {

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -28,7 +28,7 @@ public protocol HPPSwiftManagerDelegate: class {
 }
 
 /**
- *  A type-erased
+ *  A type-erased implementer of the `HPPSwiftManagerDelegate` protocol
  */
 fileprivate class AnyHPPSwiftManagerDelegate<T: Decodable>: HPPSwiftManagerDelegate {
     

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -509,7 +509,7 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
                 let decodedResponse = try? JSONDecoder().decode(T.self, from: receivedData)
             else {
                 // error
-                self.delegate?.HPPManagerFailedWithError?(error as NSError?)
+                self.delegate?.HPPManagerFailedWithError!(error as NSError?)
                 self.genericDelegate?.HPPManagerFailedWithError(error)
                 self.hppViewController.dismiss(animated: true, completion: nil)
                 return

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -504,7 +504,7 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
 
             guard
                 let receivedData = data,
-                let decodedResponse = (try? JSONSerialization.jsonObject(with: receivedData, options: [JSONSerialization.ReadingOptions.allowFragments])) as? T
+                let decodedResponse = try? JSONDecoder().decode(T.self, from: receivedData)
             else {
                 // error
                 self.delegate?.HPPManagerFailedWithError?(error as NSError?)

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -9,7 +9,7 @@ import UIKit
  */
 @objc public protocol HPPManagerDelegate {
 
-    @objc optional func HPPManagerCompletedWithResult(_ result: Dictionary <String, Any>);
+    @objc optional func HPPManagerCompletedWithResult(_ result: Dictionary <String, String>);
     @objc optional func HPPManagerFailedWithError(_ error: NSError?);
     @objc optional func HPPManagerCancelled();
 

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -28,7 +28,7 @@ public protocol GenericHPPManagerDelegate: class {
 }
 
 /**
- *  A type-erased implementer of the `HPPSwiftManagerDelegate` protocol
+ *  A type-erased implementer of the `GenericHPPManagerDelegate` protocol
  */
 fileprivate class AnyGenericHPPManagerDelegate<T: Decodable>: GenericHPPManagerDelegate {
     


### PR DESCRIPTION
Since the call on Monday, Nov 11, we've investigated this problem further and have come up with a safer, strongly-typed solution that does not break current implementations. It allows clients the flexibility to have a payment service API structure that meets their needs, while enforcing the type-safety within the SDK.

The previously displayed `enum`-based approach was problematic for a number of reasons:
- using the parsed enum on the client-side would be very difficult, requiring lots of conditionals
- it would require a large decoder to be bundled with the SDK
- it still allowed any shape of response, rather than enforcing that the shape of the response matches the payment response that is expected

This new approach uses generics in order to allow a client to initialize the HPPManager with a generic decodable type that they have defined. If a client does not wish to do this, a convenience accessor for the HPPManager will use the `[String: String]` decodable type as its generic type constraint. This convenience accessor is the default, and zero code changes would be required on any existing client's end should they choose to upgrade to a version of the SDK including this change.

We have successfully integrated this change into our payment integration, and it is working as expected - allowing us to enforce the structure of the payment response during decoding so that we can be sure that we're consuming the correct API.

This solution seems like the best approach for both LD as well as Global Payments.